### PR TITLE
fix(renovate): config:recommended instead of config:base

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "github>suzuki-shunsuke/renovate-config",
     "github>aquaproj/aqua-renovate-config#1.13.0"
   ]


### PR DESCRIPTION
Some tests for an update via renovate fail du to a migrating change requested via renovate-config-validator :
https://github.com/suzuki-shunsuke/github-action-golangci-lint/actions/runs/7138708069/job/19440707826?pr=410
```
  WARN: Config needs migrating
       "originalConfig": {
         "extends": [
           "config:base",
           "github>suzuki-shunsuke/renovate-config",
           "github>aquaproj/aqua-renovate-config#1.13.0"
         ]
       },
       "migratedConfig": {
         "extends": [
           "config:recommended",
           "github>suzuki-shunsuke/renovate-config",
           "github>aquaproj/aqua-renovate-config#1.13.0"
         ]
       }
```